### PR TITLE
Corriger la barre bleue sur l'ecran

### DIFF
--- a/css/fiche-nsi.css
+++ b/css/fiche-nsi.css
@@ -31,8 +31,9 @@ html {
 /*
  * Technique robuste pour afficher un fond sur chaque page d'un PDF.
  * On utilise un pseudo-élément 'fixed' qui se répète sur chaque page.
+ * Cette règle ne s'applique que lorsque le body a la classe 'fiche-page'.
  */
-body::before {
+body.fiche-page::before {
   content: "";
   position: fixed;
   top: 0;
@@ -67,10 +68,15 @@ h1 {
   text-align: center;
 }
 
-.container, .index-container {
+.container {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
+}
+
+/* La page d'accueil a sa propre mise en page */
+.index-container {
+  /* Les styles sont définis dans index.css */
 }
 
 section {

--- a/docs/css/fiche-nsi.css
+++ b/docs/css/fiche-nsi.css
@@ -31,8 +31,9 @@ html {
 /*
  * Technique robuste pour afficher un fond sur chaque page d'un PDF.
  * On utilise un pseudo-élément 'fixed' qui se répète sur chaque page.
+ * Cette règle ne s'applique que lorsque le body a la classe 'fiche-page'.
  */
-body::before {
+body.fiche-page::before {
   content: "";
   position: fixed;
   top: 0;
@@ -67,10 +68,15 @@ h1 {
   text-align: center;
 }
 
-.container, .index-container {
+.container {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
+}
+
+/* La page d'accueil a sa propre mise en page */
+.index-container {
+  /* Les styles sont définis dans index.css */
 }
 
 section {

--- a/docs/fiches/chaines-de-caracteres.html
+++ b/docs/fiches/chaines-de-caracteres.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="../css/fiche-nsi.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-light.min.css">
 </head>
-<body>
+<body class="fiche-page">
 
 <main>
   <header><h1>Les chaînes de caractères en Python</h1></header>

--- a/docs/fiches/structures-de-donnees.html
+++ b/docs/fiches/structures-de-donnees.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="../css/fiche-nsi.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-light.min.css">
 </head>
-<body>
+<body class="fiche-page">
 
 <main>
   <header><h1>Les Structures de Données</h1></header>

--- a/fiches/chaines-de-caracteres.html
+++ b/fiches/chaines-de-caracteres.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="../css/fiche-nsi.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-light.min.css">
 </head>
-<body>
+<body class="fiche-page">
 
 <main>
   <header><h1>Les chaînes de caractères en Python</h1></header>

--- a/fiches/structures-de-donnees.html
+++ b/fiches/structures-de-donnees.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="../css/fiche-nsi.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-light.min.css">
 </head>
-<body>
+<body class="fiche-page">
 
 <main>
   <header><h1>Les Structures de Données</h1></header>

--- a/public/css/fiche-nsi.css
+++ b/public/css/fiche-nsi.css
@@ -30,8 +30,9 @@ html {
 /*
  * Technique robuste pour afficher un fond sur chaque page d'un PDF.
  * On utilise un pseudo-élément 'fixed' qui se répète sur chaque page.
+ * Cette règle ne s'applique que lorsque le body a la classe 'fiche-page'.
  */
-body::before {
+body.fiche-page::before {
   content: "";
   position: fixed;
   top: 0;
@@ -66,10 +67,15 @@ h1 {
   text-align: center;
 }
 
-.container, .index-container {
+.container {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
+}
+
+/* La page d'accueil a sa propre mise en page */
+.index-container {
+  /* Les styles sont définis dans index.css */
 }
 
 section {

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -6,4 +6,4 @@
   <link rel="stylesheet" href="/css/fiche-nsi.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-light.min.css">
 </head>
-<body>
+<body class="fiche-page">


### PR DESCRIPTION
Fixes a blue bar display issue on the homepage by scoping background image CSS to fiche pages.

The `body::before` rule in `fiche-nsi.css` was applying a fixed background image to all pages, including the homepage, causing a visual conflict. This PR modifies the CSS to apply the background only to pages with the `fiche-page` class on their `<body>` element and adds this class to all fiche pages. It also separates the `.container` and `.index-container` styles to prevent layout conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-3abb6f5a-8460-40f9-a405-36e1817ae493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3abb6f5a-8460-40f9-a405-36e1817ae493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

